### PR TITLE
Update torrc config sed expression

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 sed -i 's/TorAddress 127.0.0.1/TorAddress 0.0.0.0/g' /etc/tor/torsocks.conf
-sed -i 's/#SOCKSPort 9050/SOCKSPort 0.0.0.0:9050/g' /etc/tor/torrc
+sed -i 's/#SocksPort 9050/SocksPort 0.0.0.0:9050/g' /etc/tor/torrc
 service privoxy start
 service tor start
 /bin/bash -c "trap : TERM INT; sleep infinity & wait"


### PR DESCRIPTION
Turns out SOCKSPort is SocksPort instead, tested, and discovered on https://stackoverflow.com/questions/57825953/cant-connect-to-dockerized-tor-proxy